### PR TITLE
First pass on refactoring the grammar towards a more classical MLTT presentation

### DIFF
--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -26,8 +26,8 @@ data KnownMods = NatMod | ListMod | VecMod | StringMod
 newtype Import = ImportLib KnownMods
 
 data Definition
-  = DefFun Name (Maybe Type) [Arg] Expr
-  | DefPatt Name [(Name,Type)] Type Name [([Arg], Expr)]
+  = DefFun Name (Maybe Type) [Arg Name Type] Expr
+  | DefPatt Name [(Name,Type)] Type Name [([Arg Name Type], Expr)]
     -- ^ Function name; name,type is parameters for roq; output type; name is input to match with for coq, constructors
   | DefTVar Name (Maybe Type) Expr
     -- ^ Define a variable (i.e. 'let') with an optional type annotation
@@ -35,7 +35,7 @@ data Definition
     -- ^ Datatype name, constructors, usually type is Set
   | DefPDataType Name [(Name, Type)] [(Name,Type)] Type
     -- ^ Datatype name, parameters, constructors, overall type
-  | DefRecType Name [Arg] Name [(Name,Type)] Type
+  | DefRecType Name [Arg Name Type] Name [(Name,Type)] Type
     -- ^ [Arg] for parameters (empty list if no params), (Maybe Name) is the type constructor
   | DefRec Name Type Name [(Name, Expr)]
     -- ^ Record name, record type, possible constructor type (this auto fills in, only needed for Chain dependent constructor test)
@@ -46,7 +46,7 @@ data Definition
     -- It is on a line of its own if True, spit out as-is and in-place if false
 
 data LocalDefn
-  = LocDefFun Name (Maybe Type) [Arg] Expr
+  = LocDefFun Name (Maybe Type) [Arg Name Type] Expr
 
 data Type 
         = PCon Name [Type]        -- (parameterized) type constructor
@@ -57,7 +57,7 @@ data Type
         | Index [Name] Type
         | Univ                    -- a Universe, aka "Type" itself, called "Set" in Agda
 
-data Arg = Arg { arg :: Name, argty :: Type }
+data Arg a b = Arg { arg :: a, argty :: b }
 
 data Expr 
   = Var Name

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -5,8 +5,9 @@ module Grammar (Module (..), Import (..), Definition (..), Type (..), Arg (..), 
   , modname
   , nat, con, num, bool, list, vec, string, suc, plus) where
 
-import Numeric.Natural (Natural)
 import Data.Text (Text)
+import Data.List.NonEmpty (NonEmpty)
+import Numeric.Natural (Natural)
 
 -- grammar
 
@@ -64,7 +65,7 @@ data Expr
   | Let [LocalDefn] Expr
   | If Expr Expr Expr
   | Where Expr [LocalDefn]
-  | App Name [Expr]
+  | App Name (NonEmpty Expr)
   | Paren Expr
   | Constructor Name
   | Lit Literal

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -3,10 +3,11 @@ module Grammar (Module (..), Import (..), Definition (..), Type (..), Arg (..), 
   , KnownMods (..), Op1 (..), Op2 (..), LocalDefn (..), Literal (..)
   , Name
   , modname
-  , nat, con, num, bool, list, vec, string, suc, plus) where
+  , nat, con, num, bool, list, vec, string, suc, plus, app1, appnm) where
 
 import Data.Text (Text)
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import Numeric.Natural (Natural)
 
 -- grammar
@@ -65,7 +66,7 @@ data Expr
   | Let [LocalDefn] Expr
   | If Expr Expr Expr
   | Where Expr [LocalDefn]
-  | App Name (NonEmpty Expr)
+  | App Expr (NonEmpty Expr)
   | Paren Expr
   | Constructor Name
   | Lit Literal
@@ -125,3 +126,9 @@ suc = Unary Suc
 
 plus :: Expr -> Expr -> Expr
 plus = Binary Plus
+
+app1 :: Name -> Expr -> Expr
+app1 a b = App (Var a) (NE.singleton b)
+
+appnm :: Name -> NonEmpty Expr -> Expr
+appnm a b = App (Var a) b

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -57,16 +57,18 @@ data Type
 
 data Arg = Arg { arg :: Name, argty :: Type }
 
-data Expr = Var Name
-        | Binary Op2 Expr Expr    -- only for known, hard-coded binary operations
-        | Unary Op1 Expr          -- only for known, hard-coded unary operations
-        | Let [LocalDefn] Expr
-        | If Expr Expr Expr
-        | Where Expr [LocalDefn]
-        | FunCall Name [Expr]    --constructor to call function
-        | Paren Expr
-        | Constructor Name
-        | Lit Literal
+data Expr 
+  = Var Name
+  | Binary Op2 Expr Expr    -- only for known, hard-coded binary operations
+  | Unary Op1 Expr          -- only for known, hard-coded unary operations
+  | Let [LocalDefn] Expr
+  | If Expr Expr Expr
+  | Where Expr [LocalDefn]
+  | App Name [Expr]
+  | Paren Expr
+  | Constructor Name
+  | Lit Literal
+  -- | Lam                  -- we don't as-yet use it?
 
 data Literal
   = Nat Natural

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -29,7 +29,7 @@ data Definition
   = DefPatt Name [(Name,Type)] Type Name [([Arg Name Type], Expr)]
     -- ^ Function name; name,type is parameters for Rocq; output type; name is input to match with for Rocq, constructors
   | DefTVar Name (Maybe Type) Expr
-    -- ^ Define a variable (i.e. 'let') with an optional type annotation
+    -- ^ Define a (top-level) variable with an optional type annotation
   | DefDataType Name [(Name,Type)] Type
     -- ^ Datatype name, constructors, usually type is Set
   | DefPDataType Name [(Name, Type)] [(Name,Type)] Type

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -1,7 +1,7 @@
 module Grammar (Module (..), Import (..), Definition (..), Type (..), Arg (..), Expr (..)
-  , KnownMods (..), Op (..), LocalDefn (..), Literal (..)
+  , KnownMods (..), Op1 (..), Op2 (..), LocalDefn (..), Literal (..)
   , modname
-  , nat, num, bool, list, vec, string) where
+  , nat, num, bool, list, vec, string, suc, plus) where
 
 import Numeric.Natural (Natural)
 
@@ -55,14 +55,14 @@ data Type = Con Name              -- type constructor
 data Arg = Arg { arg :: Name, argty :: Type }
 
 data Expr = Var Name
-        | Bin Op Expr Expr       -- only for known, hard-coded binary operations
+        | Binary Op2 Expr Expr    -- only for known, hard-coded binary operations
+        | Unary Op1 Expr          -- only for known, hard-coded unary operations
         | Let [LocalDefn] Expr
         | If Expr Expr Expr
         | Where Expr [LocalDefn]
         | FunCall Name [Expr]    --constructor to call function
         | Paren Expr
         | Constructor Name
-        | Suc Expr               -- hard-coded ??! FIXME
         | Lit Literal
 
 data Literal
@@ -83,7 +83,8 @@ data Literal
   | String String
   -- ^ String literals.
 
-data Op = Plus
+data Op2 = Plus
+data Op1 = Suc
 
 -- aliases for readability purposes
 type Name = String
@@ -109,3 +110,9 @@ vec = Lit . Vec
 
 string :: String -> Expr
 string = Lit . String
+
+suc :: Expr -> Expr
+suc = Unary Suc
+
+plus :: Expr -> Expr -> Expr
+plus = Binary Plus

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -26,9 +26,8 @@ data KnownMods = NatMod | ListMod | VecMod | StringMod
 newtype Import = ImportLib KnownMods
 
 data Definition
-  = DefFun Name (Maybe Type) [Arg Name Type] Expr
-  | DefPatt Name [(Name,Type)] Type Name [([Arg Name Type], Expr)]
-    -- ^ Function name; name,type is parameters for roq; output type; name is input to match with for coq, constructors
+  = DefPatt Name [(Name,Type)] Type Name [([Arg Name Type], Expr)]
+    -- ^ Function name; name,type is parameters for Rocq; output type; name is input to match with for Rocq, constructors
   | DefTVar Name (Maybe Type) Expr
     -- ^ Define a variable (i.e. 'let') with an optional type annotation
   | DefDataType Name [(Name,Type)] Type
@@ -49,13 +48,13 @@ data LocalDefn
   = LocDefFun Name (Maybe Type) [Arg Name Type] Expr
 
 data Type 
-        = PCon Name [Type]        -- (parameterized) type constructor
-        | DCon Name [Type] [Expr] -- dependent type constructor (note that a dependent type is also parameterized)
-        | Arr Type Type           -- function type
-        | TVar Name               -- type variable
-        | Embed Expr              -- Exprs seen as a type (should later merge properly)
-        | Index [Name] Type
-        | Univ                    -- a Universe, aka "Type" itself, called "Set" in Agda
+  = PCon Name [Type]        -- (parameterized) type constructor
+  | DCon Name [Type] [Expr] -- dependent type constructor (note that a dependent type is also parameterized)
+  | Arr Type Type           -- function type
+  | TVar Name               -- type variable
+  | Embed Expr              -- Exprs seen as a type (should later merge properly)
+  | Index [Name] Type
+  | Univ                    -- a Universe, aka "Type" itself, called "Set" in Agda
 
 data Arg a b = Arg { arg :: a, argty :: b }
 

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -49,7 +49,7 @@ data LocalDefn
 
 data Type 
   = PCon Name [Type]        -- (parameterized) type constructor
-  | DCon Name [Type] [Expr] -- dependent type constructor (note that a dependent type is also parameterized)
+  | DCon Name [Type]        -- dependent type constructor (note that a dependent type is also parameterized)
   | Arr Type Type           -- function type
   | TVar Name               -- type variable
   | Embed Expr              -- Exprs seen as a type (should later merge properly)

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -1,7 +1,7 @@
 module Grammar (Module (..), Import (..), Definition (..), Type (..), Arg (..), Expr (..)
   , KnownMods (..), Op1 (..), Op2 (..), LocalDefn (..), Literal (..)
   , modname
-  , nat, num, bool, list, vec, string, suc, plus) where
+  , nat, con, num, bool, list, vec, string, suc, plus) where
 
 import Numeric.Natural (Natural)
 
@@ -43,8 +43,8 @@ data Definition
 data LocalDefn
   = LocDefFun Name (Maybe Type) [Arg] Expr
 
-data Type = Con Name              -- type constructor
-        | PCon Name [Type]        -- parameterized type constructor
+data Type 
+        = PCon Name [Type]        -- (parameterized) type constructor
         | DCon Name [Type] [Expr] -- dependent type constructor (note that a dependent type is also parameterized)
         | Arr Type Type           -- function type
         | TVar Name               -- type variable
@@ -94,7 +94,10 @@ type Name = String
 -- useful short-hands for things that are used often
 
 nat :: Type
-nat = Con "Nat"
+nat = PCon "Nat" []
+
+con :: Name -> Type
+con n = PCon n []
 
 num :: Natural -> Expr
 num = Lit . Nat

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -1,9 +1,12 @@
+{-# Language OverloadedStrings #-}
 module Grammar (Module (..), Import (..), Definition (..), Type (..), Arg (..), Expr (..)
   , KnownMods (..), Op1 (..), Op2 (..), LocalDefn (..), Literal (..)
+  , Name
   , modname
   , nat, con, num, bool, list, vec, string, suc, plus) where
 
 import Numeric.Natural (Natural)
+import Data.Text (Text)
 
 -- grammar
 
@@ -32,7 +35,7 @@ data Definition
     -- ^ Datatype name, parameters, constructors, overall type
   | DefRecType Name [Arg] Name [(Name,Type)] Type
     -- ^ [Arg] for parameters (empty list if no params), (Maybe Name) is the type constructor
-  | DefRec Name Type Name [(String, Expr)]
+  | DefRec Name Type Name [(Name, Expr)]
     -- ^ Record name, record type, possible constructor type (this auto fills in, only needed for Chain dependent constructor test)
   | OpenName Name
     -- ^ Just for Lean, to refer to user-defined datatypes directly
@@ -87,7 +90,7 @@ data Op2 = Plus
 data Op1 = Suc
 
 -- aliases for readability purposes
-type Name = String
+type Name = Text
 
 
 --------------------------

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -1,7 +1,7 @@
 module Grammar (Module (..), Import (..), Definition (..), Type (..), Arg (..), Expr (..)
-  , KnownMods (..), Op (..), LocalDefn (..)
+  , KnownMods (..), Op (..), LocalDefn (..), Literal (..)
   , modname
-  , nat) where
+  , nat, num, bool, list, vec, string) where
 
 import Numeric.Natural (Natural)
 
@@ -55,19 +55,33 @@ data Type = Con Name              -- type constructor
 data Arg = Arg { arg :: Name, argty :: Type }
 
 data Expr = Var Name
-        | Nat Natural
-        | String String
         | Bin Op Expr Expr       -- only for known, hard-coded binary operations
         | Let [LocalDefn] Expr
         | If Expr Expr Expr
         | Where Expr [LocalDefn]
         | FunCall Name [Expr]    --constructor to call function
-        | VecE [Expr]
-        | ListE [Expr]
         | Paren Expr
         | Constructor Name
         | Suc Expr               -- hard-coded ??! FIXME
+        | Lit Literal
 
+data Literal
+  = Nat Natural
+  -- ^ Natural number literals.
+  -- We will attempt to translate these as literals like @100@
+  -- instead of @succ@ and @zero@ constructors.
+  | Bool Bool
+  -- ^ Boolean literals.
+  | List [Expr]
+  -- ^ List literals.
+  -- We will attempt to translate these as literals like @[x, y, z]@
+  -- as opposed to cons constructors.
+  | Vec [Expr]
+  -- ^ Vector literals.
+  -- We will attempt to translate these as literals like @[x, y, z]@
+  -- as opposed to @cons@ and @nil@ constructors.
+  | String String
+  -- ^ String literals.
 
 data Op = Plus
 
@@ -80,3 +94,18 @@ type Name = String
 
 nat :: Type
 nat = Con "Nat"
+
+num :: Natural -> Expr
+num = Lit . Nat
+
+bool :: Bool -> Expr
+bool = Lit . Bool
+
+list :: [ Expr ] -> Expr
+list = Lit . List
+
+vec :: [ Expr ] -> Expr
+vec = Lit . Vec
+
+string :: String -> Expr
+string = Lit . String

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -59,12 +59,19 @@ printType (DCon name types exprs) = -- For dependent type constructors
 printType (Index names ty) = braces $ typeAnn (hsep $ map pretty names) (printType ty)
 printType (Embed e) = printExpr e
 
+printLit :: Literal -> Doc ann
+printLit (Nat n) = pretty n
+printLit (Bool b) = pretty b
+printLit (String str) = dquotes $ pretty str
+printLit (Vec l) = parens $ encloseSep emptyDoc (space <> lcons <+> lbracket <> rbracket)
+  (space <> lcons <> space) (map printExpr l)
+printLit (List l) = parens $ encloseSep emptyDoc (space <> lcons <+> lbracket <> rbracket)
+  (space <> lcons <> space) (map printExpr l)
+
 -- Print expressions
 printExpr :: Expr -> Doc ann
 printExpr (Constructor name) = pretty name
 printExpr (Var var) = pretty var
-printExpr (Nat n) = pretty n
-printExpr (String str) = dquotes $ pretty str
 printExpr (Paren e) = parens $ printExpr e
 printExpr (Bin op e1 e2) = printExpr e1 <+> printOp op <+> printExpr e2
 printExpr (Let ds expr) = 
@@ -76,11 +83,8 @@ printExpr (Where expr ds) =
   printExpr expr <> line <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
 printExpr (FunCall fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
-printExpr (VecE l) = parens $ encloseSep emptyDoc (space <> lcons <+> lbracket <> rbracket)
-  (space <> lcons <> space) (map printExpr l)
-printExpr (ListE l) = parens $ encloseSep emptyDoc (space <> lcons <+> lbracket <> rbracket)
-  (space <> lcons <> space) (map printExpr l)
 printExpr (Suc t) = parens $ "suc" <+> printExpr t
+printExpr (Lit l) = printLit l
 
 printOp :: Op -> Doc ann
 printOp Plus = "+"

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -7,6 +7,7 @@ module Print.Agda
 
 import Prettyprinter
 import Prettyprinter.Render.String (renderString)
+import qualified Data.Text as T
 
 import Grammar
 
@@ -168,5 +169,4 @@ render = renderString . layoutPretty defaultLayoutOptions . get . printModule
 
 runAgda :: Module -> IO()
 runAgda m = do
-    writeFile ("out/" ++ name ++ ".agda") $ render m
-    where name = modname m
+    writeFile ("out/" ++ (T.unpack $ modname m) ++ ".agda") $ render m

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -84,7 +84,8 @@ printExpr (If cond thn els) =
 printExpr (Where expr ds) =
   printExpr expr <> line <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
-printExpr (App fun args) = printExpr fun <+> (fillSep (NE.toList $ NE.map (group . printExpr) args))
+printExpr (App fun args) = printExpr fun <+> softline' <>
+  (sep $ NE.toList $ NE.map printExpr args)
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -54,10 +54,7 @@ printType (Arr t1 t2) = printType t1 <+> arr <+> printType t2
 printType (TVar t) = pretty t
 printType (PCon t []) = pretty t
 printType (PCon name types) = pretty name <+> hsep (map printType types)
-printType (DCon name [] exprs) = -- For dependent type constructors
-    pretty name <+> hsep (map printExpr exprs)
-printType (DCon name types exprs) = -- For dependent type constructors
-    pretty name <+> hsep (map printType types) <+> hsep (map printExpr exprs)
+printType (DCon name types) = pretty name <+> hsep (map printType types)
 printType (Index names ty) = braces $ typeAnn (hsep $ map pretty names) (printType ty)
 printType (Embed e) = printExpr e
 

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -48,9 +48,9 @@ printImport (ImportLib StringMod) = import_ <+> "Agda.Builtin.String"
 -- Print types
 printType :: Type -> Doc ann
 printType (Univ) = univ
-printType (Con t) = pretty t
 printType (Arr t1 t2) = printType t1 <+> arr <+> printType t2
 printType (TVar t) = pretty t
+printType (PCon t []) = pretty t
 printType (PCon name types) = pretty name <+> hsep (map printType types)
 printType (DCon name [] exprs) = -- For dependent type constructors
     pretty name <+> hsep (map printExpr exprs)

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -84,7 +84,7 @@ printExpr (If cond thn els) =
 printExpr (Where expr ds) =
   printExpr expr <> line <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
-printExpr (App fun args) = pretty fun <+> (fillSep (NE.toList $ NE.map (group . printExpr) args))
+printExpr (App fun args) = printExpr fun <+> (fillSep (NE.toList $ NE.map (group . printExpr) args))
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -5,9 +5,10 @@ module Print.Agda
   , runAgda
   ) where
 
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import Prettyprinter
 import Prettyprinter.Render.String (renderString)
-import qualified Data.Text as T
 
 import Grammar
 
@@ -83,7 +84,7 @@ printExpr (If cond thn els) =
 printExpr (Where expr ds) =
   printExpr expr <> line <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
-printExpr (App fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
+printExpr (App fun args) = pretty fun <+> (fillSep (NE.toList $ NE.map (group . printExpr) args))
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -113,9 +113,6 @@ printDef (DefTVar var (Just t) expr) =
   typeAnn (pretty var) (printType t) <> hardline <>
   pretty var <+> assign <+> align (printExpr expr) <> hardline
 
--- Function to print function definitions
-printDef (DefFun var ty args expr) = printLocalDefn (LocDefFun var ty args expr)
-
 printDef (DefPatt var params ty _ cons) =
     typeAnn (pretty var) (printType (foldr Arr ty (map snd params))) <> line <>
     vsep (map (\(a, e) -> (pretty var) <+> hsep (map (pretty . arg) a) <+> assign <+> printExpr e) cons)

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -83,7 +83,7 @@ printExpr (If cond thn els) =
 printExpr (Where expr ds) =
   printExpr expr <> line <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
-printExpr (FunCall fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
+printExpr (App fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -73,7 +73,7 @@ printExpr :: Expr -> Doc ann
 printExpr (Constructor name) = pretty name
 printExpr (Var var) = pretty var
 printExpr (Paren e) = parens $ printExpr e
-printExpr (Bin op e1 e2) = printExpr e1 <+> printOp op <+> printExpr e2
+printExpr (Binary op e1 e2) = printExpr e1 <+> printOp2 op <+> printExpr e2
 printExpr (Let ds expr) = 
   "let" <+> align (vcat (map printLocalDefn ds) <+> "in") <> line <>
   printExpr expr
@@ -83,11 +83,14 @@ printExpr (Where expr ds) =
   printExpr expr <> line <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
 printExpr (FunCall fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
-printExpr (Suc t) = parens $ "suc" <+> printExpr t
+printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 
-printOp :: Op -> Doc ann
-printOp Plus = "+"
+printOp1 :: Op1 -> Doc ann
+printOp1 Suc = "suc"
+
+printOp2 :: Op2 -> Doc ann
+printOp2 Plus = "+"
 
 printLocalDefn :: LocalDefn -> Doc ann
 printLocalDefn (LocDefFun var ty args expr) =

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -110,7 +110,6 @@ printDef (DefTVar var (Just t) expr) =
   typeAnn (pretty var) (printType t) <> hardline <>
   pretty var <+> assign <+> align (printExpr expr) <> hardline
 
-printDef (DefFun var ty args expr) = printLocalDefn (LocDefFun var ty args expr)
 printDef (DefPatt var params ty _ cons) =
     typeAnn (pretty var) (printType (foldr Arr ty (map snd params))) <> line <>
     vsep (map (\(a, e) -> (pretty var) <+> hsep (map (pretty . arg) a) <+> assign <+> printExpr e) cons)

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -81,7 +81,7 @@ printExpr (If cond thn els) =
 printExpr (Where expr ds) =
   printExpr expr <> hardline <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
-printExpr (FunCall fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
+printExpr (App fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -7,6 +7,7 @@ module Print.Idris
 
 import Prettyprinter
 import Prettyprinter.Render.String (renderString)
+import qualified Data.Text as T
 
 import Grammar
 import Print.Generic (blanklines)
@@ -166,4 +167,4 @@ render :: Module -> String
 render = renderString . layoutPretty defaultLayoutOptions . get . printModule
 
 runIdris :: Module -> IO()
-runIdris m = writeFile ("out/" ++ modname m ++ ".idr") $ render m
+runIdris m = writeFile ("out/" ++ (T.unpack $ modname m) ++ ".idr") $ render m

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -55,9 +55,7 @@ printType (TVar t) = pretty t
 printType (PCon t []) = pretty t
 printType (PCon "Vec" [PCon baseType [], size]) = "Vect" <+> printType size <+> pretty baseType
 printType (PCon name types) = pretty name <+> hsep (map printType types)
-printType (DCon name [] exprs) = pretty name <+> hsep (map printExpr exprs)
-printType (DCon name types exprs) = -- For dependent type constructors
-    pretty name <+> hsep (map printType types) <+> hsep (map printExpr exprs)
+printType (DCon name types) = pretty name <+> hsep (map printType types)
 printType (Index names ty) = braces $ typeAnn (hsep $ punctuate comma $ map pretty names) (printType ty)
 printType (Embed e) = printExpr e
 

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -71,7 +71,7 @@ printExpr :: Expr -> Doc ann
 printExpr (Constructor name) = pretty name
 printExpr (Var var) = pretty var
 printExpr (Paren e) = parens $ printExpr e
-printExpr (Bin op e1 e2) = printExpr e1 <+> printOp op <+> printExpr e2
+printExpr (Binary op e1 e2) = printExpr e1 <+> printOp2 op <+> printExpr e2
 printExpr (Let ds expr) = 
   "let" <+> align (vcat (map printLocalDefn ds) <+> "in") <> line <>
   printExpr expr
@@ -81,11 +81,14 @@ printExpr (Where expr ds) =
   printExpr expr <> hardline <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
 printExpr (FunCall fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
-printExpr (Suc t) = parens $ "S" <+> printExpr t
+printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 
-printOp :: Op -> Doc ann
-printOp Plus = "+"
+printOp1 :: Op1 -> Doc ann
+printOp1 Suc = "S"
+
+printOp2 :: Op2 -> Doc ann
+printOp2 Plus = "+"
 
 printLocalDefn :: LocalDefn -> Doc ann
 printLocalDefn (LocDefFun var ty args expr) = 

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -60,11 +60,16 @@ printType (Index names ty) = braces $ typeAnn (hsep $ punctuate comma $ map pret
 printType (Embed e) = printExpr e
 
 
+printLit :: Literal -> Doc ann
+printLit (Nat n) = pretty n
+printLit (Bool b) = pretty b
+printLit (String str) = dquotes $ pretty str
+printLit (Vec l) =  brackets $ fillSep $ punctuate comma $ map printExpr l
+printLit (List l) = brackets $ fillSep $ punctuate comma $ map printExpr l
+
 printExpr :: Expr -> Doc ann
 printExpr (Constructor name) = pretty name
 printExpr (Var var) = pretty var
-printExpr (Nat n) = pretty n
-printExpr (String str) = dquotes $ pretty str
 printExpr (Paren e) = parens $ printExpr e
 printExpr (Bin op e1 e2) = printExpr e1 <+> printOp op <+> printExpr e2
 printExpr (Let ds expr) = 
@@ -76,9 +81,8 @@ printExpr (Where expr ds) =
   printExpr expr <> hardline <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
 printExpr (FunCall fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
-printExpr (VecE l) =  brackets $ fillSep $ punctuate comma $ map printExpr l
-printExpr (ListE l) = brackets $ fillSep $ punctuate comma $ map printExpr l
 printExpr (Suc t) = parens $ "S" <+> printExpr t
+printExpr (Lit l) = printLit l
 
 printOp :: Op -> Doc ann
 printOp Plus = "+"

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -5,9 +5,10 @@ module Print.Idris
   , runIdris
   ) where
 
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import Prettyprinter
 import Prettyprinter.Render.String (renderString)
-import qualified Data.Text as T
 
 import Grammar
 import Print.Generic (blanklines)
@@ -81,7 +82,7 @@ printExpr (If cond thn els) =
 printExpr (Where expr ds) =
   printExpr expr <> hardline <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
-printExpr (App fun args) = pretty fun <+> (fillSep (map (group . printExpr) args))
+printExpr (App fun args) = pretty fun <+> (fillSep (NE.toList $ NE.map (group . printExpr) args))
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -82,7 +82,7 @@ printExpr (If cond thn els) =
 printExpr (Where expr ds) =
   printExpr expr <> hardline <>
   indent 4 ("where" <> vcat (map printLocalDefn ds))
-printExpr (App fun args) = pretty fun <+> (fillSep (NE.toList $ NE.map (group . printExpr) args))
+printExpr (App fun args) = printExpr fun <+> (fillSep (NE.toList $ NE.map (group . printExpr) args))
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -48,10 +48,10 @@ printWithImport (ImportLib ListMod) m = m
 
 printType :: Type -> Doc ann
 printType (Univ) = univ
-printType (Con t) = pretty t
 printType (Arr t1 t2) = printType t1 <+> arr <+> printType t2
 printType (TVar t) = pretty t
-printType (PCon "Vec" [Con baseType, size]) = "Vect" <+> printType size <+> pretty baseType
+printType (PCon t []) = pretty t
+printType (PCon "Vec" [PCon baseType [], size]) = "Vect" <+> printType size <+> pretty baseType
 printType (PCon name types) = pretty name <+> hsep (map printType types)
 printType (DCon name [] exprs) = pretty name <+> hsep (map printExpr exprs)
 printType (DCon name types exprs) = -- For dependent type constructors

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -68,7 +68,7 @@ printReturnType (PCon t []) = pretty t
 printReturnType (Arr _ t) = printReturnType t
 printReturnType _ = error "show not occur as a return type"
 
-printArg :: Arg -> Doc ann
+printArg :: Pretty a => Arg a Type -> Doc ann
 printArg a = teleCell (pretty $ arg a) (printType $ argty a)
 
 printLit :: Literal -> Doc ann

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -58,8 +58,7 @@ printType (TVar t) = pretty t
 printType (PCon t []) = pretty t
 printType (PCon "Vec" args) = "Vector" <+> hsep (map printType args)
 printType (PCon name types) = pretty name <+> hsep (map printType types)
-printType (DCon name [] exprs) = pretty name <+> hsep (map printExpr exprs)
-printType (DCon name types exprs) = pretty name <+> hsep (map printType types) <+> hsep (map printExpr exprs)
+printType (DCon name types) = pretty name <+> hsep (map printType types)
 printType (Index names ty) = braces $ typeAnn (hsep (map pretty names)) (printType ty)
 printType (Embed e) = printExpr e
 

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -69,12 +69,17 @@ printReturnType _ = error "show not occur as a return type"
 printArg :: Arg -> Doc ann
 printArg a = teleCell (pretty $ arg a) (printType $ argty a)
 
+printLit :: Literal -> Doc ann
+printLit (Nat n) = pretty n
+printLit (Bool b) = pretty b
+printLit (String str) = dquotes $ pretty str
+printLit (Vec l) = "#" <> brackets (hsep $ punctuate comma (map printExpr l))
+printLit (List l) = brackets $ hsep $ punctuate comma (map printExpr l)
+
 -- Print expressions (unchanged)
 printExpr :: Expr -> Doc ann
 printExpr (Constructor name) = pretty name
 printExpr (Var var) = pretty var
-printExpr (Nat n) = pretty n
-printExpr (String str) = dquotes $ pretty str
 printExpr (Paren e) = parens $ printExpr e
 printExpr (Bin op e1 e2) = printExpr e1 <+> printOp op <+> printExpr e2
 printExpr (Let [] expr) = printExpr expr
@@ -89,9 +94,8 @@ printExpr (If cond thn els) = "if" <+> printExpr cond <+> "then" <> hardline <>
 printExpr (Where expr ds) = printExpr expr <> hardline <>
   indent 4 ("where" <> hardline <> vsep (map printLocalDefn ds))
 printExpr (FunCall fun args) = pretty fun <+> hsep (map printExpr args)
-printExpr (VecE l) = "#" <> brackets (hsep $ punctuate comma (map printExpr l))
-printExpr (ListE l) = brackets $ hsep $ punctuate comma (map printExpr l)
 printExpr (Suc t) = parens $ "Nat.succ" <+> printExpr t  -- Use `Nat.succ` explicitly
+printExpr (Lit l) = printLit l
 
 printOp :: Op -> Doc ann
 printOp Plus = "+"

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -7,6 +7,7 @@ module Print.Lean
 
 import Prettyprinter
 import Prettyprinter.Render.String (renderString)
+import qualified Data.Text as T
 
 import Grammar
 import Print.Generic
@@ -171,4 +172,4 @@ render :: Module -> String
 render = renderString . layoutPretty defaultLayoutOptions . get . printModule
 
 runLean :: Module -> IO()
-runLean m = writeFile ("out/" ++ modname m ++ ".lean") $ render m
+runLean m = writeFile ("out/" ++ (T.unpack $ modname m) ++ ".lean") $ render m

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -81,7 +81,7 @@ printExpr :: Expr -> Doc ann
 printExpr (Constructor name) = pretty name
 printExpr (Var var) = pretty var
 printExpr (Paren e) = parens $ printExpr e
-printExpr (Bin op e1 e2) = printExpr e1 <+> printOp op <+> printExpr e2
+printExpr (Binary op e1 e2) = printExpr e1 <+> printOp2 op <+> printExpr e2
 printExpr (Let [] expr) = printExpr expr
 printExpr (Let (d:[]) expr) = "let" <+> printLocalDefn d <> hardline <> printExpr expr
 printExpr (Let (d:ds) expr) = 
@@ -94,11 +94,14 @@ printExpr (If cond thn els) = "if" <+> printExpr cond <+> "then" <> hardline <>
 printExpr (Where expr ds) = printExpr expr <> hardline <>
   indent 4 ("where" <> hardline <> vsep (map printLocalDefn ds))
 printExpr (FunCall fun args) = pretty fun <+> hsep (map printExpr args)
-printExpr (Suc t) = parens $ "Nat.succ" <+> printExpr t  -- Use `Nat.succ` explicitly
+printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 
-printOp :: Op -> Doc ann
-printOp Plus = "+"
+printOp1 :: Op1 -> Doc ann
+printOp1 Suc = "Nat.succ"  -- use `Nat.succ` explicitly
+
+printOp2 :: Op2 -> Doc ann
+printOp2 Plus = "+"
 
 printLocalDefn :: LocalDefn -> Doc ann
 printLocalDefn (LocDefFun var Nothing args expr) =

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -94,7 +94,7 @@ printExpr (If cond thn els) = "if" <+> printExpr cond <+> "then" <> hardline <>
   "else" <+> printExpr els
 printExpr (Where expr ds) = printExpr expr <> hardline <>
   indent 4 ("where" <> hardline <> vsep (map printLocalDefn ds))
-printExpr (FunCall fun args) = pretty fun <+> hsep (map printExpr args)
+printExpr (App fun args) = pretty fun <+> hsep (map printExpr args)
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -5,9 +5,10 @@ module Print.Lean
   , render
   ) where
 
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import Prettyprinter
 import Prettyprinter.Render.String (renderString)
-import qualified Data.Text as T
 
 import Grammar
 import Print.Generic
@@ -94,7 +95,7 @@ printExpr (If cond thn els) = "if" <+> printExpr cond <+> "then" <> hardline <>
   "else" <+> printExpr els
 printExpr (Where expr ds) = printExpr expr <> hardline <>
   indent 4 ("where" <> hardline <> vsep (map printLocalDefn ds))
-printExpr (App fun args) = pretty fun <+> hsep (map printExpr args)
+printExpr (App fun args) = pretty fun <+> fillSep (NE.toList $ NE.map (group . printExpr) args)
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -115,10 +115,6 @@ printDef :: [Definition] -> Definition -> Doc ann
 printDef _ (DefTVar var Nothing expr) = pretty var <+> assign <+> (printExpr expr)
 printDef _ (DefTVar var (Just t) expr) = "def" <+> typeAnn (pretty var) (printType t) <+>
   assign <+> printExpr expr
-printDef _ (DefFun var Nothing args expr) = pretty var <+> hsep (map (pretty . arg) args) <+> assign <+>
-  (printExpr expr)
-printDef _ (DefFun var (Just t) args expr) = "def" <+> typeAnn (pretty var <+> hsep (map printArg args))
-  (printType t) <+> assign <+> (printExpr expr)
 printDef _ (DefPatt var params ty _ cons) =
     "def" <+> typeAnn (pretty var) (printType (foldr Arr ty (map snd params))) <> hardline <>
     vsep (map (\(a, e) -> pipe <+> (hsep $ map (pretty . arg) a) <+> "=>" <+> (printExpr e)) cons)

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -51,9 +51,9 @@ printWithImport (ImportLib ListMod) m = m
 -- Print types
 printType :: Type -> Doc ann
 printType (Univ) = univ
-printType (Con t) = pretty t
 printType (Arr t1 t2) = printType t1 <+> arr <+> printType t2
 printType (TVar t) = pretty t
+printType (PCon t []) = pretty t
 printType (PCon "Vec" args) = "Vector" <+> hsep (map printType args)
 printType (PCon name types) = pretty name <+> hsep (map printType types)
 printType (DCon name [] exprs) = pretty name <+> hsep (map printExpr exprs)
@@ -62,7 +62,7 @@ printType (Index names ty) = braces $ typeAnn (hsep (map pretty names)) (printTy
 printType (Embed e) = printExpr e
 
 printReturnType :: Type -> Doc ann
-printReturnType (Con t) = pretty t
+printReturnType (PCon t []) = pretty t
 printReturnType (Arr _ t) = printReturnType t
 printReturnType _ = error "show not occur as a return type"
 

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -95,7 +95,7 @@ printExpr (If cond thn els) = "if" <+> printExpr cond <+> "then" <> hardline <>
   "else" <+> printExpr els
 printExpr (Where expr ds) = printExpr expr <> hardline <>
   indent 4 ("where" <> hardline <> vsep (map printLocalDefn ds))
-printExpr (App fun args) = pretty fun <+> fillSep (NE.toList $ NE.map (group . printExpr) args)
+printExpr (App fun args) = printExpr fun <+> fillSep (NE.toList $ NE.map (group . printExpr) args)
 printExpr (Unary o t) = parens $ printOp1 o <+> printExpr t
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -112,10 +112,6 @@ printDef (DefTVar var Nothing expr) = pretty var <+> assign <+> printExpr expr
 printDef (DefTVar var (Just t) expr) = 
   nest 4 ("Definition" <+> typeAnn (pretty var) (printType t) <+> assign <> softline <>
   (printExpr expr <> dot <> hardline))
-printDef (DefFun var Nothing args expr) = pretty var <+> (hsep $ map (pretty . arg) args) <+> assign <+> printExpr expr
-printDef (DefFun var (Just t) args expr) = "Definition" <+> pretty var <+>
-  typeAnn (hsep $ map printArg args) (printType t) <+> assign <> softline' <> printExpr expr <> 
-  "." <> hardline
 printDef (DefPatt var params ty m cons) = "Fixpoint" <+> pretty var <+>
   typeAnn (hsep $ map (\(x, y) -> teleCell (pretty x) (printType y)) params)
           (printType ty) <+> assign <> hardline <>

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -5,6 +5,7 @@ module Print.Rocq
   , runRocq
   ) where
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 
 import Prettyprinter
@@ -89,7 +90,7 @@ printExpr (If cond thn els) = "if" <+> printExpr cond <+> "then" <+> printExpr t
 printExpr (Where expr ds) = 
   printExpr expr <> hardline <>
   indent 4 ("where " <+> vcat (map printLocalDefn ds))
-printExpr (App fun args) = pretty fun <+> (hsep $ map printExpr args)
+printExpr (App fun args) = pretty fun <+> (hsep $ NE.toList $ NE.map printExpr args)
 printExpr (Unary o e) = parens $ printOp1 o <+> printExpr e
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -71,11 +71,16 @@ printReturnType _ = error "should not occur as a return type"
 printArg :: Arg -> Doc ann
 printArg a = parens $ typeAnn (pretty $ arg a) (printType $ argty a)
 
+printLit :: Literal -> Doc ann
+printLit (Nat n) = pretty n
+printLit (Bool b) = pretty b
+printLit (String str) = dquotes $ pretty str
+printLit (Vec l) = encloseSep lbracket rbracket (semi <> space) (map printExpr l)
+printLit (List l) = encloseSep lbracket rbracket (comma <> space) (map printExpr l)
+
 printExpr :: Expr -> Doc ann
 printExpr (Constructor name) = pretty $ map toLower name
 printExpr (Var var) = pretty var
-printExpr (Nat n) = pretty n
-printExpr (String str) = dquotes $ pretty str
 printExpr (Paren e) = parens $ printExpr e
 printExpr (Bin op e1 e2) = printExpr e1 <+> printOp op <+> printExpr e2
 printExpr (Let ds expr) =
@@ -86,9 +91,8 @@ printExpr (Where expr ds) =
   printExpr expr <> hardline <>
   indent 4 ("where " <+> vcat (map printLocalDefn ds))
 printExpr (FunCall fun args) = pretty fun <+> (hsep $ map printExpr args)
-printExpr (VecE l) = encloseSep lbracket rbracket (semi <> space) (map printExpr l)
-printExpr (ListE l) = encloseSep lbracket rbracket (comma <> space) (map printExpr l)
 printExpr (Suc e) = parens $ "S" <+> printExpr e
+printExpr (Lit l) = printLit l
 
 printOp :: Op -> Doc ann
 printOp Plus = "+"

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -89,7 +89,7 @@ printExpr (If cond thn els) = "if" <+> printExpr cond <+> "then" <+> printExpr t
 printExpr (Where expr ds) = 
   printExpr expr <> hardline <>
   indent 4 ("where " <+> vcat (map printLocalDefn ds))
-printExpr (FunCall fun args) = pretty fun <+> (hsep $ map printExpr args)
+printExpr (App fun args) = pretty fun <+> (hsep $ map printExpr args)
 printExpr (Unary o e) = parens $ printOp1 o <+> printExpr e
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -82,7 +82,7 @@ printExpr :: Expr -> Doc ann
 printExpr (Constructor name) = pretty $ map toLower name
 printExpr (Var var) = pretty var
 printExpr (Paren e) = parens $ printExpr e
-printExpr (Bin op e1 e2) = printExpr e1 <+> printOp op <+> printExpr e2
+printExpr (Binary op e1 e2) = printExpr e1 <+> printOp2 op <+> printExpr e2
 printExpr (Let ds expr) =
   "let" <+> align (vcat (map printLocalDefn ds) <+> "in") <> line <>
   printExpr expr
@@ -91,11 +91,14 @@ printExpr (Where expr ds) =
   printExpr expr <> hardline <>
   indent 4 ("where " <+> vcat (map printLocalDefn ds))
 printExpr (FunCall fun args) = pretty fun <+> (hsep $ map printExpr args)
-printExpr (Suc e) = parens $ "S" <+> printExpr e
+printExpr (Unary o e) = parens $ printOp1 o <+> printExpr e
 printExpr (Lit l) = printLit l
 
-printOp :: Op -> Doc ann
-printOp Plus = "+"
+printOp1 :: Op1 -> Doc ann
+printOp1 Suc = "S"
+
+printOp2 :: Op2 -> Doc ann
+printOp2 Plus = "+"
 
 printLocalDefn :: LocalDefn -> Doc ann
 printLocalDefn (LocDefFun var Nothing args expr) = 

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -52,10 +52,10 @@ printImport (ImportLib ListMod) = emptyDoc
 
 printType :: Type -> Doc ann
 printType (Univ) = univ
-printType (Con t) = pretty $ if  "Cap_" `isPrefixOf` t || "Record" `isPrefixOf` t
-                             then t else (map toLower t) -- if starts with keyword Cap_ maintain, else lower case
 printType (Arr t1 t2) = printType t1 <+> arr <+> printType t2
 printType (TVar t) = pretty t
+printType (PCon t []) = pretty $ if  "Cap_" `isPrefixOf` t || "Record" `isPrefixOf` t
+                             then t else (map toLower t) -- if starts with keyword Cap_ maintain, else lower case
 printType (PCon "Vec" args) = "Vect" <+> hsep (map printType args)
 printType (PCon name types) = pretty (map toLower name) <+> hsep (map printType types)
 printType (DCon name [] exprs) = pretty name <+> hsep (map printExpr exprs)
@@ -64,7 +64,7 @@ printType (Index names ty) = "forall" <+> brackets (typeAnn (pretty $ map toLowe
 printType (Embed e) = printExpr e
 
 printReturnType :: Type -> Doc ann
-printReturnType (Con t) = pretty $ map toLower t --required for nested functions
+printReturnType (PCon t []) = pretty $ map toLower t --required for nested functions
 printReturnType (Arr _ t) = printReturnType t
 printReturnType _ = error "should not occur as a return type"
 
@@ -157,7 +157,7 @@ printDef (DefRec name recType consName fields) =
   where
     hasParams = case recType of
       (DCon _ tys exps) -> Just (tys, exps)
-      (Con _)           -> Nothing
+      (PCon _ _)        -> Nothing
       _                 -> error "invalid type for a record"
     parameters = maybe emptyDoc (\(tys, exps) -> (hsep $ map printType tys) <+> 
                                                  (hsep $ map printExpr exps)) hasParams

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -58,8 +58,7 @@ printType (PCon t []) = pretty $ if  "Cap_" `T.isPrefixOf` t || "Record" `T.isPr
                              then t else (T.toLower t) -- if starts with keyword Cap_ maintain, else lower case
 printType (PCon "Vec" args) = "Vect" <+> hsep (map printType args)
 printType (PCon name types) = pretty (T.toLower name) <+> hsep (map printType types)
-printType (DCon name [] exprs) = pretty name <+> hsep (map printExpr exprs)
-printType (DCon name types exprs) = pretty name <+> hsep (map printType types) <+> hsep (map printExpr exprs)
+printType (DCon name types) = pretty name <+> hsep (map printType types)
 printType (Index names ty) = "forall" <+> brackets (typeAnn (pretty $ T.toLower (T.unwords names)) (printType ty))
 printType (Embed e) = printExpr e
 
@@ -152,11 +151,10 @@ printDef (DefRec name recType consName fields) =
   indent 2 constructorCall <> dot <> hardline
   where
     hasParams = case recType of
-      (DCon _ tys exps) -> Just (tys, exps)
-      (PCon _ _)        -> Nothing
-      _                 -> error "invalid type for a record"
-    parameters = maybe emptyDoc (\(tys, exps) -> (hsep $ map printType tys) <+> 
-                                                 (hsep $ map printExpr exps)) hasParams
+      (DCon _ tys) -> Just tys
+      (PCon _ _)   -> Nothing
+      _            -> error "invalid type for a record"
+    parameters = maybe emptyDoc (\tys -> hsep $ map printType tys) hasParams
     -- Use the provided constructor name if available; otherwise, look up the default.
 
     fieldsStr = hsep $ map (printExpr . snd) fields

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -90,7 +90,7 @@ printExpr (If cond thn els) = "if" <+> printExpr cond <+> "then" <+> printExpr t
 printExpr (Where expr ds) = 
   printExpr expr <> hardline <>
   indent 4 ("where " <+> vcat (map printLocalDefn ds))
-printExpr (App fun args) = pretty fun <+> (hsep $ NE.toList $ NE.map printExpr args)
+printExpr (App fun args) = printExpr fun <+> (hsep $ NE.toList $ NE.map printExpr args)
 printExpr (Unary o e) = parens $ printOp1 o <+> printExpr e
 printExpr (Lit l) = printLit l
 

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -5,8 +5,7 @@ module Print.Rocq
   , runRocq
   ) where
 
-import Data.Char (toLower)
-import Data.List (isPrefixOf)
+import qualified Data.Text as T
 
 import Prettyprinter
 import Prettyprinter.Render.String (renderString)
@@ -54,17 +53,17 @@ printType :: Type -> Doc ann
 printType (Univ) = univ
 printType (Arr t1 t2) = printType t1 <+> arr <+> printType t2
 printType (TVar t) = pretty t
-printType (PCon t []) = pretty $ if  "Cap_" `isPrefixOf` t || "Record" `isPrefixOf` t
-                             then t else (map toLower t) -- if starts with keyword Cap_ maintain, else lower case
+printType (PCon t []) = pretty $ if  "Cap_" `T.isPrefixOf` t || "Record" `T.isPrefixOf` t
+                             then t else (T.toLower t) -- if starts with keyword Cap_ maintain, else lower case
 printType (PCon "Vec" args) = "Vect" <+> hsep (map printType args)
-printType (PCon name types) = pretty (map toLower name) <+> hsep (map printType types)
+printType (PCon name types) = pretty (T.toLower name) <+> hsep (map printType types)
 printType (DCon name [] exprs) = pretty name <+> hsep (map printExpr exprs)
 printType (DCon name types exprs) = pretty name <+> hsep (map printType types) <+> hsep (map printExpr exprs)
-printType (Index names ty) = "forall" <+> brackets (typeAnn (pretty $ map toLower (unwords names)) (printType ty))
+printType (Index names ty) = "forall" <+> brackets (typeAnn (pretty $ T.toLower (T.unwords names)) (printType ty))
 printType (Embed e) = printExpr e
 
 printReturnType :: Type -> Doc ann
-printReturnType (PCon t []) = pretty $ map toLower t --required for nested functions
+printReturnType (PCon t []) = pretty $ T.toLower t --required for nested functions
 printReturnType (Arr _ t) = printReturnType t
 printReturnType _ = error "should not occur as a return type"
 
@@ -79,7 +78,7 @@ printLit (Vec l) = encloseSep lbracket rbracket (semi <> space) (map printExpr l
 printLit (List l) = encloseSep lbracket rbracket (comma <> space) (map printExpr l)
 
 printExpr :: Expr -> Doc ann
-printExpr (Constructor name) = pretty $ map toLower name
+printExpr (Constructor name) = pretty $ T.toLower name
 printExpr (Var var) = pretty var
 printExpr (Paren e) = parens $ printExpr e
 printExpr (Binary op e1 e2) = printExpr e1 <+> printOp2 op <+> printExpr e2
@@ -120,25 +119,25 @@ printDef (DefPatt var params ty m cons) = "Fixpoint" <+> pretty var <+>
   typeAnn (hsep $ map (\(x, y) -> teleCell (pretty x) (printType y)) params)
           (printType ty) <+> assign <> hardline <>
   "match" <+> pretty m <+> "with" <> hardline <>
-  vsep (map (\(a, e) -> pipe <+> (hsep $ map (pretty . map toLower . arg) a) <+> "=>" <+> printExpr e) cons) 
+  vsep (map (\(a, e) -> pipe <+> (hsep $ map (pretty . T.toLower . arg) a) <+> "=>" <+> printExpr e) cons) 
   <> softline' <> "end" <> dot <> hardline
 printDef (DefDataType name args ty) = let
     printIndices :: Type -> Doc ann
     printIndices (Arr (Index n t) ctype) = printType (Index n t) <> comma <+> printType ctype
     printIndices t = printType t
     in
-        "Inductive" <+> typeAnn (pretty $ map toLower name) (printType ty) <+>
+        "Inductive" <+> typeAnn (pretty $ T.toLower name) (printType ty) <+>
         assign <> hardline <>
-        (vsep (map (\(x, y) -> pipe <+> typeAnn (pretty $ map toLower x) (printIndices y)) args)) <> "."
+        (vsep (map (\(x, y) -> pipe <+> typeAnn (pretty $ T.toLower x) (printIndices y)) args)) <> "."
 printDef (DefPDataType name params args ty) = let
     printIndices :: Type -> Doc ann
     printIndices (Arr (Index n t) ctype) = (printType (Index n t)) <> comma <+> (printType ctype)
     printIndices t = printType t
     in
-        "Inductive" <+> (pretty $ map toLower name) <+>
-         typeAnn (hsep (map (\(x, y) -> teleCell (pretty $ map toLower x) (printType y)) params))
+        "Inductive" <+> (pretty $ T.toLower name) <+>
+         typeAnn (hsep (map (\(x, y) -> teleCell (pretty $ T.toLower x) (printType y)) params))
                  (printType ty) <+> assign <> hardline <>
-         vsep (map (\(x, y) -> pipe <+> typeAnn (pretty $ map toLower x) (printIndices y)) args) <> dot
+         vsep (map (\(x, y) -> pipe <+> typeAnn (pretty $ T.toLower x) (printIndices y)) args) <> dot
 
 --Function for Records
 printDef (DefRecType name params consName fields _) =
@@ -190,4 +189,4 @@ render :: Module -> String
 render = renderString . layoutPretty defaultLayoutOptions . get . printModule
 
 runRocq :: Module -> IO()
-runRocq m = writeFile ("out/" ++ modname m ++ ".v") $ render m
+runRocq m = writeFile (T.unpack $ "out/" `T.append` modname m `T.append` ".v") $ render m

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -68,7 +68,7 @@ printReturnType (PCon t []) = pretty $ T.toLower t --required for nested functio
 printReturnType (Arr _ t) = printReturnType t
 printReturnType _ = error "should not occur as a return type"
 
-printArg :: Arg -> Doc ann
+printArg :: Pretty a => Arg a Type -> Doc ann
 printArg a = parens $ typeAnn (pretty $ arg a) (printType $ argty a)
 
 printLit :: Literal -> Doc ann

--- a/translators/src/Tests.hs
+++ b/translators/src/Tests.hs
@@ -74,8 +74,8 @@ _tests =
 
             -- Generate function call expressions
             genCall :: Natural -> Expr
-            genCall p = foldr (\a b -> plus (FunCall (nm 'f' a) (iter a (num . (+ 1)))) b)
-                              (FunCall "f1" [num 2]) $ reverse [2..p]
+            genCall p = foldr (\a b -> plus (App (nm 'f' a) (iter a (num . (+ 1)))) b)
+                              (App "f1" [num 2]) $ reverse [2..p]
 
         in Module "NestedFunction" [ImportLib NatMod] $ trivial n decl
     , \n -> let --4 A specified number of simple datatype declarations.
@@ -116,7 +116,7 @@ _tests =
 
         -- Generate Example Init
         genExample :: Natural -> Expr
-        genExample p = foldr (\a b -> Paren $ (FunCall (mkName "Const" a) [b])) (num 10) $ reverse [1..p]
+        genExample p = foldr (\a b -> Paren $ (App (mkName "Const" a) [b])) (num 10) $ reverse [1..p]
 
         exampleInit = DefRec "example" (con $ mkName "Record" n) (mkName "Const" n) [("example", genExample $ minusNatural n 1)] -- HACK
         decl = (genRecords n ++ [exampleInit])
@@ -236,7 +236,7 @@ _tests =
           OpenName "D",
           DefPatt "F" [("C", con "D")] nat "C" (iter n (\i -> ([Arg (nm 'C' i) (con "D")], num i))),
           DefTVar "N" (Just nat) (genCall n)]
-        genCall p = foldr (\a b -> plus (FunCall "F" [Constructor (nm 'C' a)]) b) (FunCall "F" [Constructor "C1"]) 
+        genCall p = foldr (\a b -> plus (App "F" [Constructor (nm 'C' a)]) b) (App "F" [Constructor "C1"]) 
           (reverse [2..p])
     in
        Module "Pattern_Matching_Datatypes" [ImportLib NatMod] $ trivial n decl

--- a/translators/src/Tests.hs
+++ b/translators/src/Tests.hs
@@ -2,7 +2,6 @@
 module Tests (tests) where
 
 import Data.IntMap.Strict as Map ( fromList, IntMap )
-import Data.List.NonEmpty (NonEmpty( (:|) ))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Numeric.Natural (Natural)
@@ -76,8 +75,8 @@ _tests =
 
             -- Generate function call expressions
             genCall :: Natural -> Expr
-            genCall p = foldr (\a b -> plus (App (nm 'f' a) (NE.map (num . (+ 1)) (NE.fromList [1..a]))) b)
-                              (App "f1" (NE.singleton $ num 2)) $ reverse [2..p]
+            genCall p = foldr (\a b -> plus (appnm (nm 'f' a) (NE.map (num . (+ 1)) (NE.fromList [1..a]))) b)
+                              (app1 "f1" (num 2)) $ reverse [2..p]
 
         in Module "NestedFunction" [ImportLib NatMod] $ trivial n decl
     , \n -> let --4 A specified number of simple datatype declarations.
@@ -118,7 +117,7 @@ _tests =
 
         -- Generate Example Init
         genExample :: Natural -> Expr
-        genExample p = foldr (\a b -> Paren $ (App (mkName "Const" a) (NE.singleton b))) (num 10) $ reverse [1..p]
+        genExample p = foldr (\a b -> Paren $ (app1 (mkName "Const" a) b)) (num 10) $ reverse [1..p]
 
         exampleInit = DefRec "example" (con $ mkName "Record" n) (mkName "Const" n) [("example", genExample $ minusNatural n 1)] -- HACK
         decl = (genRecords n ++ [exampleInit])
@@ -238,8 +237,8 @@ _tests =
           OpenName "D",
           DefPatt "F" [("C", con "D")] nat "C" (iter n (\i -> ([Arg (nm 'C' i) (con "D")], num i))),
           DefTVar "N" (Just nat) (genCall n)]
-        genCall p = foldr (\a b -> plus (App "F" (Constructor (nm 'C' a) :| [])) b) 
-                                        (App "F" (Constructor "C1" :| [])) 
+        genCall p = foldr (\a b -> plus (app1 "F" (Constructor (nm 'C' a))) b) 
+                                        (app1 "F" (Constructor "C1")) 
           (reverse [2..p])
     in
        Module "Pattern_Matching_Datatypes" [ImportLib NatMod] $ trivial n decl

--- a/translators/src/Tests.hs
+++ b/translators/src/Tests.hs
@@ -138,7 +138,7 @@ _tests =
         recDef = DefRecType "X" params "Const" [("sums", nat)] (con "Set")
 
         -- Build the record type application as a string: "X 1 2 ... n"
-        recTypeInstance = DCon "X" [] $ iter n num
+        recTypeInstance = DCon "X" $ iter n (Embed . num)
 
         -- Define the record instance "example" with computed field values:
         exampleInit = DefRec "example" recTypeInstance "Const" [("sums", Paren $ buildSum n)]

--- a/translators/src/Tests.hs
+++ b/translators/src/Tests.hs
@@ -2,6 +2,8 @@
 module Tests (tests) where
 
 import Data.IntMap.Strict as Map ( fromList, IntMap )
+import Data.List.NonEmpty (NonEmpty( (:|) ))
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Numeric.Natural (Natural)
 import GHC.Natural (minusNatural)
@@ -74,8 +76,8 @@ _tests =
 
             -- Generate function call expressions
             genCall :: Natural -> Expr
-            genCall p = foldr (\a b -> plus (App (nm 'f' a) (iter a (num . (+ 1)))) b)
-                              (App "f1" [num 2]) $ reverse [2..p]
+            genCall p = foldr (\a b -> plus (App (nm 'f' a) (NE.map (num . (+ 1)) (NE.fromList [1..a]))) b)
+                              (App "f1" (NE.singleton $ num 2)) $ reverse [2..p]
 
         in Module "NestedFunction" [ImportLib NatMod] $ trivial n decl
     , \n -> let --4 A specified number of simple datatype declarations.
@@ -116,7 +118,7 @@ _tests =
 
         -- Generate Example Init
         genExample :: Natural -> Expr
-        genExample p = foldr (\a b -> Paren $ (App (mkName "Const" a) [b])) (num 10) $ reverse [1..p]
+        genExample p = foldr (\a b -> Paren $ (App (mkName "Const" a) (NE.singleton b))) (num 10) $ reverse [1..p]
 
         exampleInit = DefRec "example" (con $ mkName "Record" n) (mkName "Const" n) [("example", genExample $ minusNatural n 1)] -- HACK
         decl = (genRecords n ++ [exampleInit])
@@ -236,7 +238,8 @@ _tests =
           OpenName "D",
           DefPatt "F" [("C", con "D")] nat "C" (iter n (\i -> ([Arg (nm 'C' i) (con "D")], num i))),
           DefTVar "N" (Just nat) (genCall n)]
-        genCall p = foldr (\a b -> plus (App "F" [Constructor (nm 'C' a)]) b) (App "F" [Constructor "C1"]) 
+        genCall p = foldr (\a b -> plus (App "F" (Constructor (nm 'C' a) :| [])) b) 
+                                        (App "F" (Constructor "C1" :| [])) 
           (reverse [2..p])
     in
        Module "Pattern_Matching_Datatypes" [ImportLib NatMod] $ trivial n decl

--- a/translators/src/Tests.hs
+++ b/translators/src/Tests.hs
@@ -73,7 +73,7 @@ _tests =
 
         in Module "NestedFunction" [ImportLib NatMod] $ trivial n decl
     , \n -> let --4 A specified number of simple datatype declarations.
-      genData m = foldl (\b a -> DefDataType (nm 'X' a) [(nm 'Y' a, Con (nm 'X' a))] Univ : b) [] [1..m]
+      genData m = foldl (\b a -> DefDataType (nm 'X' a) [(nm 'Y' a, con (nm 'X' a))] Univ : b) [] [1..m]
         in Module "DataSimpleDeclarations" [ImportLib NatMod]  $ genData n
     , \n ->     --5 Variable declaration with an identifier of a specified length.
            Module "LongIdentifier" [ImportLib NatMod]  $ trivial n [DefTVar (replicate (fromIntegral n) 'x') (Just nat) $ num 0]
@@ -96,7 +96,7 @@ _tests =
         xDef = DefRecType "Cap_X" [] "Const" (genFields n) Univ
 
         -- Define the example initialization
-        exampleInit = DefRec "example" (Con "Cap_X") "Const" (genExample n)
+        exampleInit = DefRec "example" (con "Cap_X") "Const" (genExample n)
 
         decl = [xDef, exampleInit]
         in Module "Fields_DependentRecordModule" [ImportLib NatMod, ImportLib VecMod] $ trivial n decl
@@ -106,13 +106,13 @@ _tests =
         -- Generate Record Definitions
         genRecords :: Natural -> [Definition]
         genRecords p = foldr (\(i,c) b -> DefRecType ("Record" ++ show i) [] ("Const" ++ show i) 
-          [(nm 'f' i, c)] Univ : b) [] $ ((1,Con "Nat") : map (\i -> (i, Con ("Record" ++ show (i-1)))) [2..p])
+          [(nm 'f' i, c)] Univ : b) [] $ ((1, nat) : map (\i -> (i, con ("Record" ++ show (i-1)))) [2..p])
 
         -- Generate Example Init
         genExample :: Natural -> Expr
         genExample p = foldr (\a b -> Paren $ (FunCall ("Const" ++ show a) [b])) (num 10) $ reverse [1..p]
 
-        exampleInit = DefRec "example" (Con $ "Record" ++ show n) ("Const" ++ show n) [("example", genExample $ minusNatural n 1)] -- HACK
+        exampleInit = DefRec "example" (con $ "Record" ++ show n) ("Const" ++ show n) [("example", genExample $ minusNatural n 1)] -- HACK
         decl = (genRecords n ++ [exampleInit])
 
         in Module "ChainDef_DependentRecordModule" [ImportLib NatMod] $ trivial n decl
@@ -128,7 +128,7 @@ _tests =
 
         -- Define the record X with param, a constructor "Const",
         -- two fields "sums" and "values", and overall type Set.
-        recDef = DefRecType "X" params "Const" [("sums", Con "Nat")] (Con "Set")
+        recDef = DefRecType "X" params "Const" [("sums", nat)] (con "Set")
 
         -- Build the record type application as a string: "X 1 2 ... n"
         recTypeInstance = DCon "X" [] $ iter n num
@@ -148,11 +148,11 @@ _tests =
         -- Generate example initialization dynamically
         genExample p = foldr (\a b -> (nm 'f' a, num 1) : b) [] [1..p]
         -- Define the example initialization
-        exampleInit = DefRec "example" (Con "Cap_X") "Const" (genExample n)
+        exampleInit = DefRec "example" (con "Cap_X") "Const" (genExample n)
     in Module "Fields_NonDependentRecordModule" [ImportLib NatMod] $ trivial n [xDef,exampleInit]
 
     , \n -> let -- 11 Description: Generate a very long chain (N) of independent record definitions
-        exampleInit = DefRec "example" (Con $ "Record" ++ show n) ("Const" ++ show n) [("f1", num 1)]
+        exampleInit = DefRec "example" (con $ "Record" ++ show n) ("Const" ++ show n) [("f1", num 1)]
         -- Generate Record Definitions
         genRecords :: Natural -> [Definition]
         genRecords p = foldl (\b a -> DefRecType ("Record" ++ show a) [] ("Const" ++ show a) [(nm 'f' a, nat)] Univ : b) 
@@ -160,11 +160,11 @@ _tests =
     in Module "ChainDefFields_NonDependentRecordModule" [ImportLib NatMod] $ trivial n (genRecords n)
 
     , \n -> --12 Description: create a simple datatype with N constructors accepting no parameters
-        Module "Constructors_Datatypes" [] $ trivial n [DefDataType "D" (iter n (\ i -> (nm 'C' i, Con "D"))) Univ]
+        Module "Constructors_Datatypes" [] $ trivial n [DefDataType "D" (iter n (\ i -> (nm 'C' i, con "D"))) Univ]
 
     , \n ->  --13 Description: creates a datatype with a single constructor accepting N parameters
         let
-            decl = [DefPDataType "D" (iter n (\i -> (nm 'p' i, Univ))) [("C", PCon "D" (iter n (Con . nm 'p')))] Univ]
+            decl = [DefPDataType "D" (iter n (\i -> (nm 'p' i, Univ))) [("C", PCon "D" (iter n (con . nm 'p')))] Univ]
         in Module "Parameters_Datatypes" [] $ trivial n decl
 
     , --14 Description: defines N variables, and uses both the first and last one in a declaration, N>=2
@@ -199,36 +199,36 @@ _tests =
     in Module "DeepDependency_VariableModule" [ImportLib NatMod] $ trivial n (genLevelDefs n)
 
     , \n -> let -- 16 Description: Simple datatype declaration with a specified number of indices, defined implicitly.
-        decl = [DefDataType "D" [("C1", Arr (Index (genIndex 'x' n) nat) (Con ("D " ++ unwords (genIndex 'x' n))))] 
+        decl = [DefDataType "D" [("C1", Arr (Index (genIndex 'x' n) nat) (con ("D " ++ unwords (genIndex 'x' n))))] 
                             (Arr (nary nat (n-1)) Univ)]
        in Module "DataImplicitIndices" [ImportLib NatMod] $ trivial n decl
 
     , \n -> let -- 17 Description: A file consisting of a single long line (length specified by the user).
-        decl = [DefTVar "A" (Just $ Con "String") $ string $ replicate (fromIntegral n) 'x']
+        decl = [DefTVar "A" (Just $ con "String") $ string $ replicate (fromIntegral n) 'x']
         in Module "SingleLongLine" [ImportLib StringMod]  $ trivial n decl
 
     , \n ->  --18 Description: A single datatype where 'n' represents the number of 'Type' parameters, all needed for 'n' constructors
         let
             decl =  [DefPDataType "D" (iter n (\i -> (nm 'p' i, Univ))) 
-                                 (iter n (\ i -> (nm 'C' i,  PCon "D" (iter n (\j -> Con (nm 'p' j) )))) ) Univ]
+                                 (iter n (\ i -> (nm 'C' i,  PCon "D" (iter n (\j -> con (nm 'p' j) )))) ) Univ]
         in Module "ConstructorsParameters_Datatypes" [] $ trivial n decl
 
     , \n -> let -- 19  Description: A single datatype where 'n' represents the number of indices, all needed for 'n' constructors
         decl = [DefDataType "D"
            (iter n (\ i -> (nm 'C' i, Arr (Index (genIndex 'x' i) nat)
-                                          (PCon "D" $ iter n (\j -> if j <= i then Con (nm 'X' j) else Con "0"))
+                                          (PCon "D" $ iter n (\j -> if j <= i then con (nm 'X' j) else con "0"))
                                       ))) (Arr (nary nat (n-1)) Univ)]
         in Module "IndicesConstructors_Datatypes" [ImportLib NatMod] $ trivial n decl
     , \n -> let -- 20  Description: A single datatype where 'n' represents the number of 'Type' parameters as well as the number of indices
         decl = [DefPDataType "D" (iter n (\i -> (nm 'p' i, Univ)))
-          [("C", Arr (Index (genIndex 'X' n) nat) (PCon "D" ((iter n (Con . nm 'p')) ++ iter n (Con . nm 'X'))))]
+          [("C", Arr (Index (genIndex 'X' n) nat) (PCon "D" ((iter n (con . nm 'p')) ++ iter n (con . nm 'X'))))]
           (Arr (nary nat (n-1)) Univ)]
         in Module "IndicesParameters_Datatypes" [ImportLib NatMod] $ trivial n decl
     ,  \n -> --21 Description: A function pattern matching on 'n' constructors of a datatype
         let
-        decl = [DefDataType "D" (iter n (\ i -> (nm 'C' i, Con "D"))) Univ, --create datatype
+        decl = [DefDataType "D" (iter n (\ i -> (nm 'C' i, con "D"))) Univ, --create datatype
           OpenName "D",
-          DefPatt "F" [("C", Con "D")] nat "C" (iter n (\i -> ([Arg (nm 'C' i) (Con "D")], num i))),
+          DefPatt "F" [("C", con "D")] nat "C" (iter n (\i -> ([Arg (nm 'C' i) (con "D")], num i))),
           DefTVar "N" (Just nat) (genCall n)]
         genCall p = foldr (\a b -> plus (FunCall "F" [Constructor (nm 'C' a)]) b) (FunCall "F" [Constructor "C1"]) 
           (reverse [2..p])

--- a/translators/test/snapshot/Parameters_DependentRecordModule.v
+++ b/translators/test/snapshot/Parameters_DependentRecordModule.v
@@ -7,6 +7,6 @@ Record X (f1 : nat) (f2 : nat) (f3 : nat) (f4 : nat) (f5 : nat) : Type := Const 
 }.
 
 Definition example : X 1 2 3 4 5 :=
-  Const  1 2 3 4 5 (1 + 2 + 3 + 4 + 5).
+  Const 1 2 3 4 5 (1 + 2 + 3 + 4 + 5).
 
 End Parameters_DependentRecordModule.


### PR DESCRIPTION
- remove unused `DefFun`
- change from `String` to `Text`
- use `NonEmpty` instead of list in a number of relevant spots
- rename `FunCall` to `App`
- introduce some smart constructors
- make `Suc` a proper unary (built-in) function instead of a weird type-level thing
- split out `Literal`
- remove `Con` (`DCon` subsumes it)
- merge the two lists of `PCon` (which now makes it essentially the same as `DCon`, but not quite in all printers)