### PR TITLE
top-level definitions always are typed.

### DIFF
--- a/generators/app/LetAddExample.hs
+++ b/generators/app/LetAddExample.hs
@@ -17,15 +17,12 @@ var x n = Var (name x n)
 names :: Text -> [Natural] -> [Text]
 names x ns = name x <$> ns
 
-vars :: Text -> [Natural] -> [Tm]
-vars x ns = Var <$> names x ns
-
 lets_ :: [(Text, Tm)] -> (Bwd Tm -> Tm) -> Tm
 lets_ = Bwd.scoped (\(x, e) -> Let [LocDefFun x Nothing [] e]) (\(x, _) -> Var x)
 
 main :: IO ()
 main = panbenchMain "LetAddExample" [ImportLib NatMod] \n ->
-  [ DefTVar "n" (Just nat) $
+  [ DefTVar "n" nat $
     lets_ (zip (names "x" [1..n]) (num 1:[plus (var "x" i) (var "x" i) | i <- [1..n-1] ])) \es ->
       Bwd.last es
   ]

--- a/generators/app/LetExample.hs
+++ b/generators/app/LetExample.hs
@@ -22,7 +22,7 @@ lets_ = Bwd.scoped (\(x, e) -> Let [LocDefFun x Nothing [] e]) (\(x, _) -> Var x
 
 main :: IO ()
 main = panbenchMain "LetExample" [ImportLib NatMod] \n ->
-  [ DefTVar "n" (Just nat) $
+  [ DefTVar "n" nat $
     lets_ (zip (names "x" [1..n]) (num 1 : vars "x" [1..n-1])) \es ->
       Bwd.last es
   ]

--- a/translators/src/Grammar.hs
+++ b/translators/src/Grammar.hs
@@ -25,8 +25,8 @@ newtype Import = ImportLib KnownMods
 data Definition
   = DefPatt Name [(Name,Tm)] Tm Name [([Arg Name Tm], Tm)]
     -- ^ Function name; name,type is parameters for Rocq; output type; name is input to match with for Rocq, constructors
-  | DefTVar Name (Maybe Tm) Tm
-    -- ^ Define a (top-level) variable with an optional type annotation
+  | DefTVar Name Tm Tm
+    -- ^ Define a (top-level) variable with a type annotation, and a definiens
   | DefDataType Name [(Name,Tm)] Tm
     -- ^ Datatype name, constructors, usually type is Set
   | DefPDataType Name [(Name, Tm)] [(Name,Tm)] Tm

--- a/translators/src/Print/Agda.hs
+++ b/translators/src/Print/Agda.hs
@@ -97,9 +97,7 @@ printLocalDefn (LocDefFun var ty args expr) =
 
 -- Function to print variable definitions
 printDef :: Definition -> Doc ann
-printDef (DefTVar var Nothing expr) = 
-  pretty var <+> assign <+> align (printTm expr) <> softline'
-printDef (DefTVar var (Just t) expr) = 
+printDef (DefTVar var t expr) = 
   typeAnn (pretty var) (printTm t) <> hardline <>
   pretty var <+> assign <+> align (printTm expr) <> hardline
 

--- a/translators/src/Print/Idris.hs
+++ b/translators/src/Print/Idris.hs
@@ -95,9 +95,7 @@ printLocalDefn (LocDefFun var ty args expr) =
             (_:_) -> pretty var <+> (hsep $ map (pretty . arg) args)
 
 printDef :: Definition -> Doc ann
-printDef (DefTVar var Nothing expr) = 
-  pretty var <+> assign <+> align (printTm expr) <> softline'
-printDef (DefTVar var (Just t) expr) = 
+printDef (DefTVar var t expr) = 
   typeAnn (pretty var) (printTm t) <> hardline <>
   pretty var <+> assign <+> align (printTm expr) <> hardline
 

--- a/translators/src/Print/Lean.hs
+++ b/translators/src/Print/Lean.hs
@@ -105,8 +105,7 @@ printLocalDefn (LocDefFun var (Just t) args expr) =
   typeAnn (prettyArgs var printArg args) (printReturnType t) <+> assign <+> printTm expr
 
 printDef :: [Definition] -> Definition -> Doc ann
-printDef _ (DefTVar var Nothing expr) = pretty var <+> assign <+> (printTm expr)
-printDef _ (DefTVar var (Just t) expr) = "def" <+> typeAnn (pretty var) (printTm t) <+>
+printDef _ (DefTVar var t expr) = "def" <+> typeAnn (pretty var) (printTm t) <+>
   assign <+> printTm expr
 printDef _ (DefPatt var params ty _ cons) =
     "def" <+> typeAnn (pretty var) (printTm (foldr Arr ty (map snd params))) <> hardline <>

--- a/translators/src/Print/Rocq.hs
+++ b/translators/src/Print/Rocq.hs
@@ -101,8 +101,7 @@ printLocalDefn (LocDefFun var (Just t) args expr) = typeAnn targs (printReturnTy
   where targs = prettyArgs var printArg args
 
 printDef :: Definition -> Doc ann
-printDef (DefTVar var Nothing expr) = pretty var <+> assign <+> printTm expr
-printDef (DefTVar var (Just t) expr) =
+printDef (DefTVar var t expr) =
   nest 4 ("Definition" <+> typeAnn (pretty var) (printTm t) <+> assign <> softline <>
   (printTm expr <> dot <> hardline))
 printDef (DefPatt var params ty m cons) = "Fixpoint" <+> pretty var <+>

--- a/translators/src/Tests.hs
+++ b/translators/src/Tests.hs
@@ -54,15 +54,15 @@ _tests :: [Natural -> Module] -- todo: add commented Haskell representation for 
 _tests =
     [ \n -> let --1
             lets p = foldr (\a b -> Let [LocDefFun (nm 'x' a) Nothing [] $ vxs (a-1)] b) (vxs p) [1..p]
-        in Module "LetExample" [ImportLib NatMod] $ trivial n [DefTVar "n" (Just nat) $ lets n]
+        in Module "LetExample" [ImportLib NatMod] $ trivial n [DefTVar "n" nat $ lets n]
 
     , \n -> let --2
         lets p = foldr (\a b -> Let [LocDefFun (nm 'x' a) Nothing [] $ sum2vars $ a-1] b) (vx p) [1..p]
-    in Module "LetAddExample" [ImportLib NatMod] $ trivial n [DefTVar "n" (Just nat) $ lets n]
+    in Module "LetAddExample" [ImportLib NatMod] $ trivial n [DefTVar "n" nat $ lets n]
 
     , -- 3 Description: Generate Nested Functions
     \n -> let --3
-            decl = [ DefTVar "n" (Just nat) (Let (reverse $ genFunc n) (genCall n)) ]
+            decl = [ DefTVar "n" nat (Let (reverse $ genFunc n) (genCall n)) ]
             -- Generate function definitions dynamically based on (1 to n)
             genFunc :: Natural -> [LocalDefn]
             genFunc p = foldr (\a b -> LocDefFun (nm 'f' a)
@@ -82,7 +82,7 @@ _tests =
       genData m = foldl (\b a -> DefDataType (nm 'X' a) [(nm 'Y' a, con (nm 'X' a))] Univ : b) [] [1..m]
         in Module "DataSimpleDeclarations" [ImportLib NatMod]  $ genData n
     , \n ->     --5 Variable declaration with an identifier of a specified length.
-           Module "LongIdentifier" [ImportLib NatMod]  $ trivial n [DefTVar (T.pack $ replicate (fromIntegral n) 'x') (Just nat) $ num 0]
+           Module "LongIdentifier" [ImportLib NatMod]  $ trivial n [DefTVar (T.pack $ replicate (fromIntegral n) 'x') nat $ num 0]
 
     -- 6 Description: A record declaration with N dependent fields
     ,\n -> let --6
@@ -177,9 +177,9 @@ _tests =
      \n ->
     let
         -- result = x1 + xn
-        resultDef = DefTVar "result" (Just nat) $ plus (Var "x1") (vx n)
+        resultDef = DefTVar "result" nat $ plus (Var "x1") (vx n)
 
-        decl = foldl (\b a -> DefTVar (nm 'x' a) (Just nat) (num a) : b) [resultDef] $ reverse [1..n]
+        decl = foldl (\b a -> DefTVar (nm 'x' a) nat (num a) : b) [resultDef] $ reverse [1..n]
     in Module "FirstLast_VariableModule" [ImportLib NatMod] $ trivial n decl
     , -- 15 Description: defines lots of dependent variables (10 at each level of dependency) and then use the most nested ones in a declaration
     \n -> let
@@ -194,12 +194,12 @@ _tests =
     genTm idx level = if level == 0 then num idx else plus (Var $ varName level idx) (num idx)
 
     --  sum of all xN_1 .. xN_10 + 100
-    resultDef = DefTVar "result" (Just nat) $ foldl (\acc idx -> plus acc (Var $ varName n idx)) (num 100) [1..varsPerLevel]
+    resultDef = DefTVar "result" nat $ foldl (\acc idx -> plus acc (Var $ varName n idx)) (num 100) [1..varsPerLevel]
 
     -- Generate DefTVar for each level
     genLevelDefs :: Natural -> [Definition]
     genLevelDefs level =
-        foldl (\b a -> iter varsPerLevel (\idx -> DefTVar (varName a idx) (Just nat) (genTm idx (a-1))) ++ b) [resultDef]
+        foldl (\b a -> iter varsPerLevel (\idx -> DefTVar (varName a idx) nat (genTm idx (a-1))) ++ b) [resultDef]
         $ reverse [1..level]
 
     in Module "DeepDependency_VariableModule" [ImportLib NatMod] $ trivial n (genLevelDefs n)
@@ -210,7 +210,7 @@ _tests =
        in Module "DataImplicitIndices" [ImportLib NatMod] $ trivial n decl
 
     , \n -> let -- 17 Description: A file consisting of a single long line (length specified by the user).
-        decl = [DefTVar "A" (Just $ con "String") $ string $ replicate (fromIntegral n) 'x']
+        decl = [DefTVar "A" (con "String") $ string $ replicate (fromIntegral n) 'x']
         in Module "SingleLongLine" [ImportLib StringMod]  $ trivial n decl
 
     , \n ->  --18 Description: A single datatype where 'n' represents the number of 'Type' parameters, all needed for 'n' constructors
@@ -235,7 +235,7 @@ _tests =
         decl = [DefDataType "D" (iter n (\ i -> (nm 'C' i, con "D"))) Univ, --create datatype
           OpenName "D",
           DefPatt "F" [("C", con "D")] nat "C" (iter n (\i -> ([Arg (nm 'C' i) (con "D")], num i))),
-          DefTVar "N" (Just nat) (genCall n)]
+          DefTVar "N" nat (genCall n)]
         genCall p = foldr (\a b -> plus (app1 "F" (con (nm 'C' a))) b)
                                         (app1 "F" (con "C1"))
           (reverse [2..p])


### PR DESCRIPTION
It was already the case in all the examples, so it just sufficed to remove the `Maybe`.